### PR TITLE
Python34

### DIFF
--- a/pico8/game/game.py
+++ b/pico8/game/game.py
@@ -20,6 +20,8 @@ from ..map.map import Map
 from ..sfx.sfx import Sfx
 from ..music.music import Music
 
+from ..lua.lua import LuaMinifyTokenWriter
+
 HEADER_TITLE_STR = 'pico-8 cartridge // http://www.pico-8.com\n'
 HEADER_VERSION_RE = re.compile('version (\d+)\n')
 HEADER_VERSION_PAT = 'version {}\n'
@@ -85,6 +87,9 @@ class Game():
 
         self.version = None
 
+        self.title = None
+        self.byline = None
+
     @classmethod
     def make_empty_game(cls, filename=None, version=DEFAULT_VERSION):
         """Create an empty game.
@@ -126,7 +131,7 @@ class Game():
         """
         assert filename.endswith('.p8.png') or filename.endswith('.p8')
         if filename.endswith('.p8'):
-            with open(filename, 'r', encoding='utf-8') as fh:
+            with open(filename, 'r', encoding='iso-8859-1', errors='backslashreplace') as fh:
                 g = Game.from_p8_file(fh, filename=filename)
         else:
             with open(filename, 'rb') as fh:
@@ -169,8 +174,75 @@ class Game():
             elif section:
                 section_lines[section].append(line)
 
+        # Grab the title and byline.
+        title = None
+        byline = None
+        if len(section_lines['lua']) > 1:
+            title = section_lines['lua'][0]
+            byline = section_lines['lua'][1]
+            if title[:2] == '--':
+                title = title[2:]
+                if byline[:2] == '--':
+                    byline = byline[2:]
+                else:
+                    byline = None
+            else:
+                title = None
+                byline = None
+
+        #######################################
+        # if ???:                             #
+        # Need to make this section optional. #
+        #######################################
+        # Look for CONSTANT tags and process them.
+        # That is, replace all constant references with their value
+        # and remove the constant declarations to reclaim their tokens.
+        # Assumptions:
+        #   One constant assignment per line like so:
+        #       --[[const]] foo = 1
+        #   No other code on line. Line will be commented out like so:
+        #       --[[const]]-- foo = 1
+        #   Later comment okay:
+        #       --[[const]] foo = 1   -- this is foo
+        #   Keep the right side simple. e.g. Simplified literals.
+        #     This will be a straight text replace in the code.
+        #     Thus, anything complex will add tokens rather than save.
+        #   No other lines should contain "--[[const]]" for any reason.
+        #   Everything is case sensitive.
+        CONSTANT_TAG = '--[[const]]'
+        game_constants = {}
+        for l in section_lines['lua']:
+            tag_start = l.find(CONSTANT_TAG)
+            if tag_start > -1:
+                tag_end = tag_start + len(CONSTANT_TAG)
+                op = l.find('=', tag_end + 1)
+                if op > -1:
+                    comment_start = l.find('--', op + 2)
+                    ckey = l[tag_end:op].strip()
+                    cval = l[op + 1:comment_start if comment_start > -1 else len(l)].strip()
+                    if ckey:
+                        game_constants.update({ckey: cval})
+                        #print(ckey + ': ' + cval)
+        # Must loop twice because it is possible to declare a global
+        # in a function below where it is used.
+        #for l in section_lines['lua']:
+        for i in range(len(section_lines['lua'])):
+            l = section_lines['lua'][i]
+            # Don't replace the constant declaration itself...
+            if l.find(CONSTANT_TAG) > -1:
+                # comment it out...
+                l = l.replace(CONSTANT_TAG, CONSTANT_TAG + '--')
+            else:
+                # and replace all other references to it with its value.
+                for c in game_constants.items():
+                    l = re.sub(r'\b' + c[0] + r'\b', c[1], l)
+            # This is where I needed the index iterator.
+            section_lines['lua'][i] = l
+
         new_game = cls.make_empty_game(filename=filename)
         new_game.version = version
+        new_game.title = title
+        new_game.byline = byline
         for section in section_lines:
             if section == 'lua':
                 new_game.lua = Lua.from_lines(
@@ -647,11 +719,51 @@ class Game():
                 PICO8_LUA_CHAR_LIMIT))
 
         outstr.write(SECTION_DELIM_PAT.format('lua'))
+        # There is surely a better way to check this:
+        if lua_writer_cls == LuaMinifyTokenWriter:
+            # Of course, the above char count is now off.
+            if self.title:
+                outstr.write('--' + self.title)
+            if self.byline:
+                outstr.write('--' + self.byline)
+
         ended_in_newline = None
+        lbuffer = ''
+        char_count = 0
+        transformed_char_count = transformed_lua.get_char_count()
         for l in self.lua.to_lines(writer_cls=lua_writer_cls,
                                    writer_args=lua_writer_args):
-            outstr.write(l)
             ended_in_newline = l.endswith('\n')
+            lbuffer += l
+            char_count += len(l)
+            if ended_in_newline or char_count == transformed_char_count:
+                # Last-chance fix to edge cases needing spaces around arithmetic assignments.
+                # Regex for this is a lot simpler than I was first testing,
+                # but no guarantees on it working for all cases.
+                # "[^\s\)]|\)[^a-z]" means no spaces and no ")" unless it is a ")" followed by
+                # something other than a letter.  In other words, ingore "()" if used on
+                # the left side (possible?), but if ")" is the last char of the previous
+                # statement, then that is okay (which would look like: "...)someletter+=..." ).
+                #
+                # Left, then right, separately.  (Can't use re.finditer due to expansion.)
+                while True:
+                    m = re.search(r'(\]|\})[a-z]([^\s\)]|\)[^a-z]| and | or |not )*(\+=|-=|\*=|\/=|%=)', lbuffer)
+                    if m:
+                        lbuffer = lbuffer[:m.start()+1] + ' ' + lbuffer[m.start()+1:]
+                        #print(lbuffer)
+                    else:
+                        break
+                while True:
+                    m = re.search(r'(\+=|-=|\*=|\/=|%=)(\S| and | or |not )*(\]|\))[a-z]', lbuffer)
+                    if m:
+                        lbuffer = lbuffer[:m.end()-1] + ' ' + lbuffer[m.end()-1:]
+                        #print(lbuffer)
+                    else:
+                        break
+                outstr.write(lbuffer)
+                lbuffer = ''
+            #outstr.write(l)
+            #ended_in_newline = l.endswith('\n')
         if not ended_in_newline:
             outstr.write('\n')
 
@@ -735,7 +847,7 @@ class Game():
         if filename.endswith('.png'):
             file_args = {'mode':'wb+'}
         else:
-            file_args = {'mode':'w+', 'encoding':'utf-8'}
+            file_args = {'mode':'w+', 'encoding':'iso-8859-1'}
         with tempfile.TemporaryFile(**file_args) as outfh:
             if filename.endswith('.png'):
                 if kwargs.get('label_fname', None) is None:

--- a/pico8/gfx/gfx.py
+++ b/pico8/gfx/gfx.py
@@ -92,7 +92,8 @@ class Gfx(util.BaseSection):
             for b in self._data[start_i:end_i]:
                 newdata.append((b & 0x0f) << 4 | (b & 0xf0) >> 4)
                 
-            yield bytes(newdata).hex() + '\n'
+            #Python 3.5###yield bytes(newdata).hex() + '\n'
+            yield ''.join(format(b, '02x') for b in newdata) + '\n'
 
     def get_sprite(self, id, tile_width=1, tile_height=1):
         """Retrieves the graphics data for a sprite.

--- a/pico8/lua/lua.py
+++ b/pico8/lua/lua.py
@@ -22,7 +22,8 @@ PICO8_LUA_COMPRESSED_CHAR_LIMIT = 15360
 
 
 PICO8_BUILTINS = {
-    '_init', '_update', '_draw',
+    '_init', '_update', '_update60', '_draw',
+    'setmetatable', 'cocreate', 'coresume', 'costatus', 'yield',
     'load', 'save', 'folder', 'ls', 'run', 'resume', 'reboot', 'stat', 'info',
     'flip', 'printh', 'clip', 'pget', 'pset', 'sget', 'sset', 'fget', 'fset',
     'print', 'cursor', 'color', 'cls', 'camera', 'circ', 'circfill', 'line',
@@ -34,6 +35,7 @@ PICO8_BUILTINS = {
     'count',  # deprecated function
     'mapdraw',  # deprecated function
     'self',   # a special name in Lua OO
+    '_update_buttons'  # announced for 30/60 fps compat but not yet/ever used ???
 }
 
 

--- a/pico8/music/music.py
+++ b/pico8/music/music.py
@@ -88,8 +88,10 @@ class Music(util.BaseSection):
             chan2 = self._data[start_i+1] & 127
             chan3 = self._data[start_i+2] & 127
             chan4 = self._data[start_i+3] & 127
-            yield (bytes([p8flags]).hex() + ' ' +
-                   bytes([chan1, chan2, chan3, chan4]).hex() + '\n')
+            #Python 3.5###yield (bytes([p8flags]).hex() + ' ' +
+            ###       bytes([chan1, chan2, chan3, chan4]).hex() + '\n')
+            yield (''.join(format(b, '02x') for b in [p8flags]) + ' ' +
+                   ''.join(format(b, '02x') for b in [chan1, chan2, chan3, chan4]) + '\n')
 
     def get_channel(self, id, channel):
         """Gets the sfx ID on a channel for a given pattern.

--- a/pico8/sfx/sfx.py
+++ b/pico8/sfx/sfx.py
@@ -129,11 +129,14 @@ class Sfx(util.BaseSection):
           One line of a hex string.
         """
         for id in range(0, 64):
-            hexstrs = [bytes(self.get_properties(id)).hex()]
+            #Python 3.5###hexstrs = [bytes(self.get_properties(id)).hex()]
+            hexstrs = [''.join(format(b, '02x') for b in self.get_properties(id))]
             for note in range(0, 32):
                 pitch, waveform, volume, effect = self.get_note(id, note)
-                hexstrs.append(bytes([pitch, waveform << 4 | volume]).hex())
-                hexstrs.append(bytes([effect]).hex()[1])
+                #Python 3.5###hexstrs.append(bytes([pitch, waveform << 4 | volume]).hex())
+                #Python 3.5###hexstrs.append(bytes([effect]).hex()[1])
+                hexstrs.append(''.join(format(b, '02x') for b in [pitch, waveform << 4 | volume]))
+                hexstrs.append(''.join(format(b, '02x') for b in [effect])[1])
             yield ''.join(hexstrs) + '\n'
 
     def get_note(self, id, note):

--- a/pico8/util.py
+++ b/pico8/util.py
@@ -118,7 +118,8 @@ class BaseSection():
             end_i = start_i + self.HEX_LINE_LENGTH_BYTES
             if end_i > len(self._data):
                 end_i = len(self._data)
-            yield bytes(self._data[start_i:end_i]).hex() + '\n'
+            #Python 3.5###yield bytes(self._data[start_i:end_i]).hex() + '\n'
+            yield ''.join(format(b, '02x') for b in self._data[start_i:end_i]) + '\n'
     
     @classmethod
     def from_bytes(cls, data, version):


### PR DESCRIPTION
First task was to get this running on Cygwin (and Babun) which is currently limited to Python 3.4.  Thus, `bytes().hex()` had to be replaced with something equivalent.  This is the source of issue https://github.com/dansanderson/picotool/issues/9 .  That issue can be closed if you state the requirement as Python 3.5+ or adopt my alternative (which might also allow for earlier than 3.4, but not Python 2.x -- you are way beyond Python 2).

The rest is pretty well explained by the code comments.

I just today made some extra effort the get the glyph handling compatible with all scenarios -- which is more than what I had before to fit just my needs and some variants.  That was pretty tough to chase out the settings for without switching to binary mode.  Python needs a raw 8-bit ASCII+ text mode.  raw_unicode_escape almost worked but it bombed on a "...\U..." I happened to have in a comment (good thing too because I almost went with it).

Regarding the edge cases with minifying arithmetic assignments, this from my notes might help:

```
a={1}b=a[1]b=3  -- works
a={1}b=a[1]b+=3  -- boom!  unexpected symbol near '='
a={1}b=a[1] b+=3  -- works
a={1}b=(a[1])b+=3  -- works
a={1}b+=a[1] b+=3  -- boom!  unexpected symbol near '='
a={1}b+=(a[1])b+=3  -- boom!  unexpected symbol near '='
a={1} b+=(a[1])b+=3  -- boom!  unexpected symbol near '='
a={1} b+=(a[1]) b+=3  -- works
a={1} b+=a[1]b=3  -- boom!  unexpected symbol near '='
```

I know you can't merge the whole shebang because I didn't write in proper optional handling of the features I added.  I only quick-modded to get` luamin` and `build --lua` working with .p8 files for automating builds from Sublime Text.