### PR TITLE
Add --watch flag to build

### DIFF
--- a/pico8/build/build.py
+++ b/pico8/build/build.py
@@ -359,3 +359,5 @@ def do_watch(args):
     except KeyboardInterrupt:
         watcher.stop()
     watcher.join()
+
+    return 0

--- a/pico8/build/build.py
+++ b/pico8/build/build.py
@@ -124,7 +124,8 @@ class DirWatcher:
         # Watch has done its job, strip it
         args.watch = None
         handler = BuildEventHandler(callback, args,
-            patterns=args.watch_glob.split(',')
+            patterns=args.watch_glob.split(','),
+            ignore_patterns=['*/' + args.filename]
         )
 
         self.observer = Observer()

--- a/pico8/build/build.py
+++ b/pico8/build/build.py
@@ -121,7 +121,9 @@ class RequireWalker(lua.BaseASTWalker):
 
 class DirWatcher:
     def __init__(self, watchdir, callback, args):
-        handler = BuildEventHandler( callback, args,
+        # Watch has done its job, strip it
+        args.watch = None
+        handler = BuildEventHandler(callback, args,
             patterns=args.watch_glob.split(',')
         )
 

--- a/pico8/tool.py
+++ b/pico8/tool.py
@@ -570,6 +570,12 @@ def _get_argparser():
         '--empty-music', action='store_true',
         help='use an empty music region (overrides default)')
     sp_build.add_argument(
+        '--watch', type=str, nargs="?", const="",
+        help='specify a directory to watch and automatically build on changes')
+    sp_build.add_argument(
+        '--watch-glob', type=str, default="*.p8,*.png,*.lua",
+        help='comma-separated list of globs to watch for')
+    sp_build.add_argument(
         'filename', type=str,
         help='filename of the output cart; if the file exists, '
              'the cart is used as the default input for each region not '


### PR DESCRIPTION
I had heard of picotool's build functionality and hoped it had this feature. No dice, but I was glad to see it was on the list (#25). So, I went ahead and threw together a basic implementation.

This could be polished further, but I think it's pretty functional already. It adds two flags to the `build` command. `--watch[=dir]` will cause `picotool` to sit and watch the given directory (default current directory) for changes. `--watch-glob` allows specifying what files to watch - by default, it only watches `*.lua,*.p8,*.png`.

When any change to a watched file happens, it just runs `build` with whatever other arguments are provided.

It's just a thin wrapper around [https://github.com/gorakhargosh/watchdog](watchdog), which I found after a brief search. It met my criteria of cross-platform and seeming mature/supported enough, and using it was actually super nice. I made the include optional - so if it is not there, the rest of picotool will work, but `--watch` will give a nice message saying to install watchdog to enable it. The stub classes to squelch errors in the code that requires it is my design, I don't know if there's some more standard way of doing that.

I'm certainly open to feedback, on substance or style - give it a whirl and let me know what you think!