### PR TITLE
Added missing PICO-8 built-ins, and reordered table to match docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,12 @@ cls()
 ...
 ```
 
+### p8tool luamin2
+
+The `luamin2` tool works almost identically to the `luamin` tool but uses a moreLua-savvy parser and performs fewer code changes. It is less aggressive than `luamin` and so does not compress as well, but will sometimes result in working code when `luamin` will not.
+
+The same sorts of warnings apply to `luamin2` as apply to `luamin`. Generally it is better if you do not run this tool as keeping PICO-8 code understandable is a worthwhile goal in itself. That being said there will occasionally be times where the original source cannot be saved as a cartridge while the minified one can. For these rare situations the tool can be handy.
+
 
 ### p8tool listtokens
 

--- a/pico8/lua/lexer.py
+++ b/pico8/lua/lexer.py
@@ -151,7 +151,7 @@ class TokString(Token):
                 c = bytes([c])
                 if c in _STRING_REVERSE_ESCAPES:
                     escaped_chrs.append(b'\\' + _STRING_REVERSE_ESCAPES[c])
-                elif (c[0] > 125 and c[0] < 154) or (c[0] >= 65 and c[0] <= 90):
+                elif (c[0] > 125 and c[0] < 154) or (c[0] >= 65 and c[0] <= 90) or (c[0] in (34, 39)):
                     # Special PICO-8 graphics characters and small letters
                     # should be left alone
                     escaped_chrs.append(b'\\' + bytes(str(ord(c)), 'utf-8'))

--- a/pico8/lua/lexer.py
+++ b/pico8/lua/lexer.py
@@ -151,12 +151,12 @@ class TokString(Token):
                 c = bytes([c])
                 if c in _STRING_REVERSE_ESCAPES:
                     escaped_chrs.append(b'\\' + _STRING_REVERSE_ESCAPES[c])
-                elif (c[0] > 125 and c[0] < 154) or (c[0] >= 65 and c[0] <= 90) or (c[0] in (34, 39)):
+                elif (c[0] > 125 and c[0] < 154) or (c[0] >= 65 and c[0] <= 90):
                     # Special PICO-8 graphics characters and small letters
                     # should be left alone
                     escaped_chrs.append(b'\\' + bytes(str(ord(c)), 'utf-8'))
                 elif c == self._quote:
-                    escaped_chrs.append(b'\\{}' + c)
+                    escaped_chrs.append(b'\\' + c)
                 else:
                     escaped_chrs.append(c)
             return self._quote + b''.join(escaped_chrs) + self._quote

--- a/pico8/lua/lexer.py
+++ b/pico8/lua/lexer.py
@@ -151,8 +151,12 @@ class TokString(Token):
                 c = bytes([c])
                 if c in _STRING_REVERSE_ESCAPES:
                     escaped_chrs.append(b'\\' + _STRING_REVERSE_ESCAPES[c])
+                elif (c[0] > 125 and c[0] < 154) or (c[0] >= 65 and c[0] <= 90):
+                    # Special PICO-8 graphics characters and small letters
+                    # should be left alone
+                    escaped_chrs.append(b'\\' + bytes(str(ord(c)), 'utf-8'))
                 elif c == self._quote:
-                    escaped_chrs.append(b'\\' + c)
+                    escaped_chrs.append(b'\\{}' + c)
                 else:
                     escaped_chrs.append(c)
             return self._quote + b''.join(escaped_chrs) + self._quote

--- a/pico8/lua/lua.py
+++ b/pico8/lua/lua.py
@@ -982,6 +982,12 @@ class LuaMinifyWriter(LuaASTEchoWriter):
                 break
         return b''.join(spaces_without_semis)
 
+    def _walk_VarAttribute(self, node):
+        for t in self._walk(node.exp_prefix):
+            yield t
+        yield self._get_text(node, b'.')
+        yield self._get_name(node, node.attr_name, True)
+
     def _walk_FieldNamedKey(self, node):
         yield self._get_name(node, node.key_name, True)
         yield self._get_text(node, b'=')

--- a/pico8/lua/lua.py
+++ b/pico8/lua/lua.py
@@ -20,25 +20,54 @@ PICO8_LUA_CHAR_LIMIT = 32768
 PICO8_LUA_TOKEN_LIMIT = 8192
 PICO8_LUA_COMPRESSED_CHAR_LIMIT = 15360
 
-
+# These are in the same order as they are found in the PICO-8 manual.
 PICO8_BUILTINS = {
-    b'_init', b'_update', b'_update60', b'_draw',
-    b'setmetatable', b'getmetatable', b'cocreate', b'coresume', b'costatus', b'yield',
-    b'load', b'save', b'folder', b'ls', b'run', b'resume', b'reboot', b'stat', b'info',
-    b'flip', b'printh', b'clip', b'pget', b'pset', b'sget', b'sset', b'fget', b'fset',
-    b'print', b'cursor', b'color', b'cls', b'camera', b'circ', b'circfill', b'line',
-    b'rect', b'rectfill', b'pal', b'palt', b'spr', b'sspr', b'add', b'del', b'all',
-    b'foreach', b'pairs', b'btn', b'btnp', b'sfx', b'music', b'mget', b'mset', b'map',
-    b'peek', b'poke', b'memcpy', b'reload', b'cstore', b'memset', b'max', b'min', b'mid',
-    b'flr', b'cos', b'sin', b'atan2', b'sqrt', b'abs', b'rnd', b'srand', b'band', b'bor',
-    b'bxor', b'bnot', b'shl', b'shr', b'cartdata', b'dget', b'dset', b'sub', b'sgn',
-    b'stop', b'menuitem', b'type', b'tostr', b'tonum', b'extcmd', b'ls', b'fillp',
-    b'time', b'assert',
-    b'_update_buttons',  # announced for 30/60 fps compatibility but not yet used?
+    # System
+    b'load', b'save', b'folder', b'dir', b'ls', b'run', b'stop', b'resume',
+    b'reboot', b'info', b'flip', b'printh', b'stat', b'extcmd',
+    # Program Structure
+    b'_update', b'_draw', b'_init', b'_update60',
+    # Graphics
+    b'clip', b'pget', b'pset', b'sget', b'sset', b'fget', b'fset', b'print', b'cursor',
+    b'color', b'cls', b'camera', b'circ', b'circfill', b'line', b'rect', b'rectfill',
+    b'pal', b'palt', b'spr', b'sspr', b'fillp',
+    # Tables
+    b'add', b'del', b'all', b'foreach', b'pairs',
+    # Input
+    b'btn', b'btnp',
+    # Audio
+    b'sfx', b'music',
+    # Map
+    b'mget', b'mset', b'map',
+    # Memory
+    b'peek', b'poke', b'peek4', b'poke4', b'memcpy', b'reload', b'cstore', b'memset',
+    # Math
+    b'max', b'min', b'mid', b'flr', b'ceil', b'cos', b'sin', b'atan2', b'sqrt', b'abs',
+    b'rnd', b'srand', b'band', b'bor', b'bxor', b'bnot', b'rotl', b'rotr', b'shl',
+    b'shr', b'lshr',
+    # Custom Menu Items
+    b'menuitem',
+    # Strings
+    b'sub',
+    # Types
+    b'type', b'tostr', b'tonum',
+    # Cartridge Data
+    b'cartdata', b'dget', b'dset',
+    # Additional Lua Features
+    b'setmetatable', b'getmetatable',
+    b'cocreate', b'coresume', b'costatus', b'yield',
+    # Mentioned In Manual (but not fully documented)
+    b'assert', b'sgn',
+    b'?',   # alias for "print"
+    # Deprecated
     b'count',  # deprecated function
     b'mapdraw',  # deprecated function
+    b'time',
+    # Announced
+    b'_update_buttons',  # announced for 30/60 fps compatibility but not yet used?
+    # Lua
     b'self',   # a special name in Lua OO
-    b'?',   # alias for "print"
+    # Internal
     b'__index'  # internal function sometimes used by carts
 }
 

--- a/pico8/lua/lua.py
+++ b/pico8/lua/lua.py
@@ -904,6 +904,8 @@ class LuaMinifyWriter(LuaASTEchoWriter):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._name_factory = MinifyNameFactory()
+        # We want to preserve the first two comments as they are significant to PICO-8.
+        self.comment_count = 0
 
     def _get_name(self, node, tok, leave_it_be=False):
         """Gets the minified name for a TokName.
@@ -940,9 +942,13 @@ class LuaMinifyWriter(LuaASTEchoWriter):
                 isinstance(self._tokens[self._pos], lexer.TokComment))):
             if not isinstance(self._tokens[self._pos], lexer.TokComment):
                 strs.append(self._tokens[self._pos].code)
+            elif self.comment_count < 2:
+                # This condition keeps the first two comments.
+                strs.append(self._tokens[self._pos].code)
+                self.comment_count += 1
             self._pos += 1
 
-        if (start_pos == 0) or (self._pos == len(self._tokens)):
+        if (start_pos == 0 and self.comment_count == 0) or (self._pos == len(self._tokens)):
             # Eliminate all spaces at beginning and end of code.
             return b''
 

--- a/pico8/lua/lua.py
+++ b/pico8/lua/lua.py
@@ -1071,6 +1071,7 @@ class LuaMinifyTokenWriter(BaseLuaWriter):
         self._name_factory = MinifyNameFactory()
         self._last_was_name_keyword_number = False
         self._last_was_newline = True
+        self._approx_count = 0
 
     def to_lines(self):
         """
@@ -1079,7 +1080,9 @@ class LuaMinifyTokenWriter(BaseLuaWriter):
         """
         for token in self._tokens:
             if (token.matches(lexer.TokComment) or
-                token.matches(lexer.TokSpace)):
+                token.matches(lexer.TokSpace)) and self._approx_count > 2:
+                # Strip out comments except for the first two which are significant
+                # to PICO-8's cartridge creation system.
                 continue
             elif token.matches(lexer.TokNewline):
                 # Preserve non-consecutive newlines. This is the easiest way to handle Pico-8's newline-dependent
@@ -1110,6 +1113,7 @@ class LuaMinifyTokenWriter(BaseLuaWriter):
                 self._last_was_name_keyword_number = token.code in b'])}'
                 self._last_was_newline = False
                 yield token.code
+            self._approx_count += 1
 
 
 class LuaFormatterTokenWriter(LuaASTEchoWriter):

--- a/pico8/tool.py
+++ b/pico8/tool.py
@@ -299,6 +299,21 @@ def luamin(g, out_fname, args=None):
               lua_writer_cls=lua.LuaMinifyTokenWriter)
             
 
+def luamin2(g, out_fname, args=None):
+    """Conservatively reduces the Lua code for a cart to reduce character count.
+
+    This is very similar to luamin, but is more conservative about renaming
+    table fields.
+
+    Args:
+      g: The Game.
+      out_fname: The output filename, for error messages.
+      args: The argparse parsed args object, or None.
+    """
+    g.to_file(filename=out_fname,
+              lua_writer_cls=lua.LuaMinifyWriter)
+            
+
 def luafmt(g, out_fname, args=None):
     """Rewrite the Lua code for a cart to use regular formatting.
 
@@ -402,6 +417,11 @@ def do_luamin(args):
     return process_game_files(args.filename, luamin, args=args)
 
 
+def do_luamin2(args):
+    """Executor for the luamin2 command."""
+    return process_game_files(args.filename, luamin2, args=args)
+
+
 def do_luafmt(args):
     """Executor for the luafmt command."""
     return process_game_files(args.filename, luafmt,
@@ -469,6 +489,14 @@ def _get_argparser():
         'filename', type=str, nargs='+',
         help='the names of files to process')
     sp_luamin.set_defaults(func=do_luamin)
+
+    sp_luamin2 = subparsers.add_parser(
+        'luamin2',
+        help='minifies the Lua code for a cart (using the parser), reducing the character count')
+    sp_luamin2.add_argument(
+        'filename', type=str, nargs='+',
+        help='the names of files to process')
+    sp_luamin2.set_defaults(func=do_luamin2)
 
     sp_luafmt = subparsers.add_parser(
         'luafmt',


### PR DESCRIPTION
A handful of PICO-8 built-ins were missing and getting their names incorrectly changed by the minifier; there was also a built-in included twice. These differences were hard to spot because the ordering of the built-ins was almost, but not exactly, like the ordering in the PICO-8 manual. This change puts all the built-ins in the order found in the PICO-8 manual divided up into the same sections used by the manual. The built-ins that are not documented in the manual are included in separate sections following.