### PR TITLE
Write correct version string to p8 files.

### DIFF
--- a/pico8/game/game.py
+++ b/pico8/game/game.py
@@ -596,7 +596,7 @@ class Game():
         """
         outstr.write(HEADER_TITLE_STR)
 
-        outstr.write(b'version 8\n')
+        outstr.write(bytes('version %s\n' % self.version, 'utf-8'))
 
         # Sanity-check the Lua written by the writer.
         transformed_lua = Lua.from_lines(


### PR DESCRIPTION
Noticed the version string wasn't outputting correctly for p8 files, and this change seems to fix it.

Let me know if I need to update any tests.. I took a look but I wasn't sure what I would need to do.
