### PR TITLE
Install empty cart image

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     description='Tools and Python libraries for manipulating PICO-8 game files',
     license='MIT',
     packages=find_packages(where='.', exclude=['tests', 'tests.*']),
-    include_package_data=True,
+    package_data={'pico8': ['game/empty_023.p8.png']},
     setup_requires=[
         'pytest-runner',
     ],


### PR DESCRIPTION
Fixes **FileNotFoundError** caused by the missing file. The argument `include_package_data=True` installs files specified in the `MANIFEST.in` file, which does not exist.