### PR TITLE
Don't use short names that the user has reserved

### DIFF
--- a/pico8/lua/lua.py
+++ b/pico8/lua/lua.py
@@ -1324,7 +1324,7 @@ class MinifyNameFactory():
             while True:
                 new_name = self._name_for_id(self._next_name_id)
                 self._next_name_id += 1
-                if new_name not in MinifyNameFactory.PRESERVED_NAMES:
+                if (new_name not in MinifyNameFactory.PRESERVED_NAMES) and (new_name not in self._names_to_keep):
                     break
             self._name_map[name] = new_name
             util.debug('- minifying name "{}" to "{}"\n'.format(

--- a/pico8/lua/lua.py
+++ b/pico8/lua/lua.py
@@ -1270,7 +1270,7 @@ class MinifyNameFactory():
         self._next_name_id = 0
 
         self._keep_all_names = keep_all_names
-        self._names_to_keep = None
+        self._names_to_keep = set()
 
         if keep_property_names:
             # TODO: crawl file for property names, define self._names_to_keep
@@ -1316,7 +1316,7 @@ class MinifyNameFactory():
             return name
         if name in MinifyNameFactory.PRESERVED_NAMES:
             return name
-        if self._names_to_keep is not None and name in self._names_to_keep:
+        if name in self._names_to_keep:
             return name
 
         if name not in self._name_map:


### PR DESCRIPTION
When minifying a cart, it's possible to synthesize short names that overwrite names that the user has elected to keep.

I don't know if there's a different fix that you might prefer, but this option works for me.