### PR TITLE
Add pytest-xdist depencency to pydevtool.txt and tests_require

### DIFF
--- a/pydevtools.txt
+++ b/pydevtools.txt
@@ -6,6 +6,7 @@ flake8
 mypy
 sphinx
 pytest
+pytest-xdist
 coverage
 ipython
 rstcheck

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'mypy',
         'pypng',
         'pytest',
+        'pytest-xdist',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This PR proposes to add pytest-xdist to the lists of dependencies to allow developers to run the tests out of the box, without having to manually install pytest-xdist.

When I first checked out the repo and tried to run the tests, I was met by an error: `unrecognized arguments: -n4`. I'm guessing that this argument was added to pytest.ini to enable multithreaded test execution through pytest-xdist? If so, I added it as a dependency in pydevtool.txt so that developers should be able to run the tests directly after following the development setup instructions.

I also added it to the `tests_require` list in setup.py because it seemed like the right thing to do. I'm not really a python dev though, so this is mostly a guess.