### PR TITLE
Disable P8SCII unescaping to fix mangling of emoji characters

### DIFF
--- a/pico8/game/formatter/p8.py
+++ b/pico8/game/formatter/p8.py
@@ -308,7 +308,7 @@ class P8Formatter(BaseFormatter):
         for line in game.lua.to_lines(
                 writer_cls=lua_writer_cls,
                 writer_args=lua_writer_args):
-            outstr.write(bytes(lua.p8scii_to_unicode(line), 'utf-8'))
+            outstr.write(line)
             ended_in_newline = line.endswith(b'\n')
         if not ended_in_newline:
             outstr.write(b'\n')

--- a/pico8/lua/lexer.py
+++ b/pico8/lua/lexer.py
@@ -161,9 +161,7 @@ class TokString(Token):
             escaped_chrs = []
             for c in self._data:
                 c = bytes([c])
-                if c in _STRING_REVERSE_ESCAPES:
-                    escaped_chrs.append(b'\\' + _STRING_REVERSE_ESCAPES[c])
-                elif c == self._quote:
+                if c == self._quote:
                     escaped_chrs.append(b'\\' + c)
                 else:
                     escaped_chrs.append(c)
@@ -375,18 +373,6 @@ class Lexer():
                     self._in_string = None
                     i += 1
                     break
-
-                if c == b'\\':
-                    # Escape character.
-                    num_m = re.match(br'\d{1,3}', s[i+1:])
-                    if num_m:
-                        c = bytes([int(num_m.group(0))])
-                        i += len(num_m.group(0))
-                    else:
-                        next_c = s[i+1:i+2]
-                        if next_c in _STRING_ESCAPES:
-                            c = _STRING_ESCAPES[next_c]
-                            i += 1
 
                 self._in_string.append(c)
                 i += 1

--- a/tests/pico8/game/formatter/formatter_test.py
+++ b/tests/pico8/game/formatter/formatter_test.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+import unittest
+
+from pico8.game.formatter.p8 import P8Formatter
+from pico8.game import game
+from pico8.lua import lua
+from io import BytesIO
+
+class TestP8Formatter(unittest.TestCase):
+	def testEmojisArePreservedThroughFormatting(self):
+		lua_code = 'print(\"Hello Emoji 🅾️\")'
+		lua_code_utf8_bytes = lua_code.encode('utf-8')
+		emoji_bytes = '🅾️'.encode('utf-8')
+
+		output_cart = game.Game.make_empty_game('dummy.p8')
+		output_cart.lua = lua.Lua.from_lines([lua_code_utf8_bytes], version=8)
+		
+		cart_stream = BytesIO()
+
+		formatter = P8Formatter()
+		formatter.to_file(
+			output_cart,
+			cart_stream,
+			lua_writer_cls = lua.LuaEchoWriter)
+
+		cart_bytes = cart_stream.getvalue()
+
+		assert(emoji_bytes in cart_bytes)

--- a/tests/pico8/lua/lexer_test.py
+++ b/tests/pico8/lua/lexer_test.py
@@ -257,13 +257,6 @@ class TestLexer(unittest.TestCase):
                          lxr._tokens[0])
         self.assertEqual(lexer.TokKeyword(b'and'), lxr._tokens[2])
 
-    def testStringEscapes(self):
-        lxr = lexer.Lexer(version=4)
-        lxr._process_line(b'"\\\n\\a\\b\\f\\n\\r\\t\\v\\\\\\"\\\'\\65"\n')
-        self.assertEqual(2, len(lxr._tokens))
-        self.assertEqual(lexer.TokString(b'\n\a\b\f\n\r\t\v\\"\'A'),
-                         lxr._tokens[0])
-
     def testComment(self):
         lxr = lexer.Lexer(version=4)
         lxr._process_line(b'-- comment text and stuff\n')


### PR DESCRIPTION
## TL;DR
This PR addresses an issue where any emoji symbols in the input lua script would be replaced by a garbled sequence of characters. The proposed solution is to remove picotool's current handling of P8SCII escape sequences which does not seem to function as intended.

## The Details
I encountered an issue where any use of the 🅾️ emoji in my lua script would be replaced by "ユか✽ゆヤま◆" after building a .p8 cart with picotool. The cause of this issue seems to stem from P8SCII being treated as an encoding in itself. In practice, this treatment boils down to two steps:
1. When parsing a string literal, the lexer replaces any numerical P8SCII escape sequence it encounters with a byte of the specified value, seemingly hoping that this results in a "pure" P8SCII string.
2. Later, the P8 formatter calls `lua.p8scii_to_unicode`, which seems meant to convert all P8SCII characters in the passed string to their utf-8 counterparts. The formatter assumes, at this point, that the lua script is P8SCII encoded. As a side note, this substitution routine runs on the entire script and not just on the string tokens that had their escape sequences converted by the lexer in step 1.

Both of the above steps have inherent issues:
1. Replacing P8SCII escape sequences with their corresponding byte values does not turn the input string in its entirety into a P8SCII encoded string as the majority of the string retains its original encoding (utf-8). What we end up with instead is a mix of utf-8 and P8SCII.
2. The assumption that the passed string is P8SCII encoded is incorrect. It is, In fact, mostly utf-8 with a few dashes of P8SCII encoded characters as a result of step 1. When this conversion routine encounters the seven byte long utf-8 character for 🅾️, it will replace each of the seven bytes with a new utf-8 character, resulting in "ユか✽ゆヤま◆".

## Future Improvements
- I would argue against treating P8SCII as a text encoding, instead merely treating it as a collection of escape sequences that hold a special meaning when passed to Pico-8's `print` function and passing them through unchanged. If pre-interpreting these escape sequences is still a desired feature, I'd suggest it be done in one go when parsing or writing the string tokens instead of passing through an intermediate format.
- There are probably additional code paths or data structures that are made dead by this change and could be removed.